### PR TITLE
Hotfix/ref branch

### DIFF
--- a/.github/workflows/pr-submit.yml
+++ b/.github/workflows/pr-submit.yml
@@ -23,10 +23,7 @@ jobs:
             - name: Download Plan
               uses: actions/download-artifact@v4
               with:
-                name: tfplan-${{ github.ref_name == 'main' && 'prod' || 'dev' }}
-            
-            - name: verifica o ref_name
-              run: echo ${{ github.ref_name == 'main' && 'prod' || github.ref_name == 'dev' && 'dev' || 'feat' }}
+                name: tfplan-${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
             
             - name: Verificar Plan
               run: cat plan.txt 

--- a/.github/workflows/pr-submit.yml
+++ b/.github/workflows/pr-submit.yml
@@ -8,6 +8,8 @@ jobs:
     tf_plan:
         uses: Adenilson365/tf-labs01-aws-k8s/.github/workflows/terraform-plan.yml@main
         secrets: inherit
+        with: 
+          context: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
     pr_submit:
         needs: tf_plan
         runs-on: ubuntu-latest

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,10 +1,14 @@
 name: Terraform Plan
 on:
   workflow_call:
+    inputs: 
+      conext:
+        required: true
+        type: string
 jobs:
   terraform_plan: 
-    name: Terraform plan ${{ github.ref_name == 'main' && 'prod' || github.ref_name == 'dev' && 'dev' || 'feat' }}
-    environment: ${{ github.ref_name == 'main' && 'prod' || github.ref_name == 'dev' && 'dev' || 'feat' }}
+    name: Terraform plan ${{ inputs.conext == 'main' && 'prod' || inputs.conext == 'dev' && 'dev' || 'feat' }}
+    environment: ${{ inputs.conext == 'main' && 'prod' || inputs.conext == 'dev' && 'dev' || 'feat' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -12,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: verifica o ref_name
-        run: echo ${{ github.ref_name == 'main' && 'prod' || github.ref_name == 'dev' && 'dev' || 'feat' }}
+        run: echo ${{ inputs.conext }}"
 
       
       - name: Configurar AWS credentials CLI de Deploy
@@ -60,7 +64,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: tfplan-${{ github.ref_name == 'main' && 'prod' || github.ref_name == 'dev' && 'dev' || 'feat' }}
+          name: tfplan-${{ inputs.conext == 'main' && 'prod' || inputs.conext == 'dev' && 'dev' || 'feat' }}
           path: ./plan.txt
           overwrite: true
 

--- a/.github/workflows/tf-plan-dev.yml
+++ b/.github/workflows/tf-plan-dev.yml
@@ -10,6 +10,8 @@ jobs:
     tf_plan:
         uses: Adenilson365/tf-labs01-aws-k8s/.github/workflows/terraform-plan.yml@dev
         secrets: inherit
+        with: 
+          context: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
     
     tf-plan-output:
         needs: tf_plan


### PR DESCRIPTION
- Anteriormente sempre que o plan era chamado, está recebendo como parâmetro o github.ref_name, que traz o nome da branch que está executando o código.
- Com isso o código do pr sempre usava o state da branch de feat
- foi alterado para passar a usar no pr o base_ref, que armazena o nome da branch que sobre a ação no pr